### PR TITLE
Retrieve cf output variables

### DIFF
--- a/CF/index.js
+++ b/CF/index.js
@@ -3,12 +3,10 @@
  * Retrieve CloudFormation information within a lambda.
  */
 
-var async = require('asyncawait/async'),
-    await = require('asyncawait/await'),
-    Promise = require('bluebird'),
+var Promise = require('bluebird'),
     AWS = require('aws-sdk');
 
-var cloudformation = new AWS.CloudFormation({apiVersion: '2010-05-15'});
+var cloudformation = new AWS.CloudFormation({apiVersion: '2010-05-15', region: process.env.SERVERLESS_REGION });
 
 var CF = {
 };
@@ -16,43 +14,48 @@ var CF = {
 /**
  * Load CF output variables into environment
  */
-CF.loadVars = async (function() {
+CF.loadVars = function () {
   // Build CF stack name
-  if (!process.env.SERVERLESS_PROJECT || !process.env.SERVERLESS_STAGE) {
-    throw new Error("Serverless environment not set");
+  if (!process.env.SERVERLESS_PROJECT || !process.env.SERVERLESS_STAGE || !process.env.SERVERLESS_REGION) {
+    return Promise.fail(new Error("Serverless environment not set"));
   }
-  stackName = process.env.SERVERLESS_PROJECT + "-" + process.env.SERVERLESS_STAGE + "-r";
 
-  return await (CF.describeCFStack(stackName)
-                  .then(function(stackDescription) {
-                    if (!stackDescription.hasOwnProperty('Outputs') || stackDescription.Outputs.constructor !== Array) {
-                      return Promise.reject(new Error("No outputs in stack description"));
-                    }
+  var stackName = process.env.SERVERLESS_PROJECT + "-" + process.env.SERVERLESS_STAGE + "-r";
+  return CF._describeCFStack(stackName)
+    .then(function(stackDescription) {
+      if (!stackDescription.hasOwnProperty('Outputs') || stackDescription.Outputs.constructor !== Array) {
+        return Promise.reject(new Error("No outputs in stack description"));
+      }
 
-                    return Promise.each(stackDescription.Outputs, function (outVar) {
-                      process.env["SERVERLESS_CF_" + outVar.OutputKey] = outVar.OutputValue;
-                      return null;
-                    });
-                  })
-                  .catch(function (err) {
-                    console.log("WARN: Error retrieving CF variables");
-                  }));
-});
+      return Promise.each(stackDescription.Outputs, function (outVar) {
+        process.env["SERVERLESS_CF_" + outVar.OutputKey] = outVar.OutputValue;
+        return null;
+      });
+    })
+    .catch(function (err) {
+      console.log("WARN: Error retrieving CF variables");
+      return Promise.reject(err);
+    });
+};
 
 /**
  * Get the CF stack description
  */
-CF._describeCFStack = Promise.method(function(stackName) {
-  cloudformation.describeStacks({ StackName: stackname }, function(err, data) {
-    if (err) {
-      throw err;
-    }
-    if (!data.Stacks || data.Stacks.constructor !== Array || data.Stacks.length === 0) {
-      throw new Error("invalid response", data);
-    }
-    // Return only the stack description
-    return data.Stacks[0];
+CF._describeCFStack = function(stackName) {
+  return new Promise(function(resolve,reject) {
+    cloudformation.describeStacks({ StackName: stackName }, function(err, data) {
+      if (err) {
+        reject(err);
+      }
+      
+      if (!data || !data.Stacks || data.Stacks.constructor !== Array || data.Stacks.length === 0) {
+        reject(new Error("invalid response", data));
+      }
+      
+      // Return only the stack description
+      resolve(data.Stacks[0]);
+    });
   })
-});
+};
 
 module.exports = CF;

--- a/CF/index.js
+++ b/CF/index.js
@@ -16,11 +16,11 @@ var CF = {
  */
 CF.loadVars = function () {
   // Build CF stack name
-  if (!process.env.SERVERLESS_PROJECT || !process.env.SERVERLESS_STAGE || !process.env.SERVERLESS_REGION) {
-    return Promise.fail(new Error("Serverless environment not set"));
+  if ((!process.env.SERVERLESS_PROJECT_NAME || !process.env.SERVERLESS_STAGE || !process.env.SERVERLESS_REGION)) {
+    return Promise.reject(new Error("Serverless environment not set"));
   }
 
-  var stackName = process.env.SERVERLESS_PROJECT + "-" + process.env.SERVERLESS_STAGE + "-r";
+  var stackName = process.env.SERVERLESS_PROJECT_NAME + "-" + process.env.SERVERLESS_STAGE + "-r";
   return CF._describeCFStack(stackName)
     .then(function(stackDescription) {
       if (!stackDescription.hasOwnProperty('Outputs') || stackDescription.Outputs.constructor !== Array) {

--- a/CF/index.js
+++ b/CF/index.js
@@ -1,0 +1,58 @@
+'use strict';
+/**
+ * Retrieve CloudFormation information within a lambda.
+ */
+
+var async = require('asyncawait/async'),
+    await = require('asyncawait/await'),
+    Promise = require('bluebird'),
+    AWS = require('aws-sdk');
+
+var cloudformation = new AWS.CloudFormation({apiVersion: '2010-05-15'});
+
+var CF = {
+};
+
+/**
+ * Load CF output variables into environment
+ */
+CF.loadVars = async (function() {
+  // Build CF stack name
+  if (!process.env.SERVERLESS_PROJECT || !process.env.SERVERLESS_STAGE) {
+    throw new Error("Serverless environment not set");
+  }
+  stackName = process.env.SERVERLESS_PROJECT + "-" + process.env.SERVERLESS_STAGE + "-r";
+
+  return await (CF.describeCFStack(stackName)
+                  .then(function(stackDescription) {
+                    if (!stackDescription.hasOwnProperty('Outputs') || stackDescription.Outputs.constructor !== Array) {
+                      return Promise.reject(new Error("No outputs in stack description"));
+                    }
+
+                    return Promise.each(stackDescription.Outputs, function (outVar) {
+                      process.env["SERVERLESS_CF_" + outVar.OutputKey] = outVar.OutputValue;
+                      return null;
+                    });
+                  })
+                  .catch(function (err) {
+                    console.log("WARN: Error retrieving CF variables");
+                  }));
+});
+
+/**
+ * Get the CF stack description
+ */
+CF._describeCFStack = Promise.method(function(stackName) {
+  cloudformation.describeStacks({ StackName: stackname }, function(err, data) {
+    if (err) {
+      throw err;
+    }
+    if (!data.Stacks || data.Stacks.constructor !== Array || data.Stacks.length === 0) {
+      throw new Error("invalid response", data);
+    }
+    // Return only the stack description
+    return data.Stacks[0];
+  })
+});
+
+module.exports = CF;

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Serverless Helpers (Node.js Version)
 To have your lambda access the CF output variables you have to give it the `cloudformation:describeStacks` access rights in the lambda IAM role.
 
 The CF.loadVars() promise will add all CF output variables to the process'
-environment as *SERVERLESS_CF_<OutVar name>*. It will add a few ms to the
+environment as *SERVERLESS_CF_`OutVar name`*. It will add a few ms to the
 startup time of your lambda.
 
 Change your lambda handler as follows:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Serverless Helpers (Node.js Version)
 
 ###Features
 * Helps your modules locate and load Stage Variables that the Serverless framework adds on deployment.
-* Allows access to the CF Output variables that you defined in the `s-template.json` file.
+* Allows access to the CF Output variables that you defined in the `s-resources-cf.json` file.
 
 ## CF Output variables
 To have your lambda access the CF output variables you have to give it the `cloudformation:describeStacks` access rights in the lambda IAM role.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ module.exports.handler = function(event, context) {
       return context.done(error, response);
     });
   })
+  .catch(function(err) {
+    return context.done(err, null);
+  });
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,4 +3,33 @@ Serverless Helpers (Node.js Version)
 
 ###Features
 * Helps your modules locate and load Stage Variables that the Serverless framework adds on deployment.
+* Allows access to the CF Output variables that you defined in the `s-template.json` file.
+
+## CF Output variables
+To have your lambda access the CF output variables you have to give it the `cloudformation:describeStacks` access rights in the lambda IAM role.
+
+The CF.loadVars() promise will add all CF output variables to the process'
+environment as *SERVERLESS_CF_<OutVar name>*. It will add a few ms to the
+startup time of your lambda.
+
+Change your lambda handler as follows:
+
+```
+// Require Serverless ENV vars
+var ServerlessHelpers = require('serverless-helpers-js');
+ServerlessHelpers.loadEnv();
+
+// Require Logic
+var lib = require('../lib');
+
+// Lambda Handler
+module.exports.handler = function(event, context) {
+  ServerlessHelpers.CF.loadVars()
+  .then(function() {
+    lib.respond(event, function(error, response) {
+      return context.done(error, response);
+    });
+  })
+};
+```
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,11 @@ var ServerlessHelpers = {
   loadEnv: function() {
     require('./env');
   },
+  
+  // Retrieve CF output variables
+  // For now has to be called AFTER loadEnv() as we need
+  // the SERVERLESS variables to compose the CF stack name.
+  CF: require('./CF'),
 
   // Shim interacting with Lambda to a callback call
   shimCallback: function(method) {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "aws-sdk": "^2.2.38"
   },
   "dependencies": {
-    "asyncawait": "^1.0.3",
     "bluebird": "^3.3.3",
     "dotenv": "^1.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "serverless-helpers-js",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Helper functions for Serverless modules.",
-  "author": "Austen Collins <austen@servant.co>, Ryan Pendergast <ryan.pendergast@gmail.com>",
+  "author": "Austen Collins <austen@servant.co>, Ryan Pendergast <ryan.pendergast@gmail.com>, Frank Schmid <fschmid740@googlemail.com>",
   "license": "MIT",
   "main": "index.js",
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/serverless/serverless-helpers-js"
+    "type": "git",
+    "url": "https://github.com/serverless/serverless-helpers-js"
   },
   "keywords": [
     "serverless",
@@ -16,8 +16,12 @@
     "lambda",
     "api gateway"
   ],
-  "devDependencies": {},
+  "devDependencies": {
+    "aws-sdk": "^2.2.38"
+  },
   "dependencies": {
+    "asyncawait": "^1.0.3",
+    "bluebird": "^3.3.3",
     "dotenv": "^1.2.0"
   }
 }


### PR DESCRIPTION
Added functionality to use CF output variables within lambda functions. Similar to loadEnv(), CF.loadVars() will store the variables within the lambda process' environment.
For detailed description see README
