### PR TITLE
Do not init cf globally

### DIFF
--- a/CF/index.js
+++ b/CF/index.js
@@ -6,8 +6,6 @@
 var Promise = require('bluebird'),
     AWS = require('aws-sdk');
 
-var cloudformation = new AWS.CloudFormation({apiVersion: '2010-05-15', region: process.env.SERVERLESS_REGION });
-
 var CF = {
 };
 
@@ -43,6 +41,8 @@ CF.loadVars = function () {
  */
 CF._describeCFStack = function(stackName) {
   return new Promise(function(resolve,reject) {
+    var cloudformation = new AWS.CloudFormation({apiVersion: '2010-05-15', region: process.env.SERVERLESS_REGION });
+
     cloudformation.describeStacks({ StackName: stackName }, function(err, data) {
       if (err) {
         reject(err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-helpers-js",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Helper functions for Serverless modules.",
   "author": "Austen Collins <austen@servant.co>, Ryan Pendergast <ryan.pendergast@gmail.com>, Frank Schmid <fschmid740@googlemail.com>",
   "license": "MIT",


### PR DESCRIPTION
Due to some optimizations of Node or the optimizer, the initialization of the cloudformation object could happen (and actually happened) within the global context before sls-helpers could load the environment variables.
Now the initialization is done locally within the accessor method.
Also increased version to 0.2.1 to allow silent updates.
@ac360 Please merge and deploy a new NPM. Thanks :-)
